### PR TITLE
cast esearch results from map to list for py3 compat

### DIFF
--- a/srapy/__init__.py
+++ b/srapy/__init__.py
@@ -119,7 +119,7 @@ def accession_to_id(accession, force=False):
     except ValueError:
         # Lookup numeric ID from accession
         term = '{}[Accession]'.format(accession)
-        ids = esearch_ids(db='sra', term=term)
+        ids = list(esearch_ids(db='sra', term=term))
         if len(ids) == 1:
             return ids[0]
         else:


### PR DESCRIPTION
When running on Python 3, `map()` returns a generator, and so when using an accession the following is thrown:

```
SRApy version 0.1.16

Traceback (most recent call last):
  File "/home/camille/miniconda/envs/boink/lib/python3.6/site-packages/srapy/__init__.py", line 115, in accession_to_id
    raise ValueError
ValueError

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/camille/miniconda/envs/boink/bin/get-run.py", line 105, in <module>
    main()
  File "/home/camille/miniconda/envs/boink/bin/get-run.py", line 82, in main
    uids.append(accession_to_id(id_or_acc, force=opts['-a']))
  File "/home/camille/miniconda/envs/boink/lib/python3.6/site-packages/srapy/__init__.py", line 123, in accession_to_id
    if len(ids) == 1:
TypeError: object of type 'map' has no len()
```

This fixes the problem by casting it to a list.